### PR TITLE
Fix test scenarios color when it contains at least undefined step

### DIFF
--- a/src/main/resources/cucumber/formatter/style.css
+++ b/src/main/resources/cucumber/formatter/style.css
@@ -165,6 +165,11 @@ body {
   background-color:  #2DEAEC;
 }
 
+.undefined .header {
+  color: #000;
+  background-color: #EAEC2D;
+}
+
 .failed .header {
   background: rgb(196, 13, 13);
 }


### PR DESCRIPTION
Currently test scenarios with at least one undefined test step show as green, when the test scenario is actually undefined and failed.
This fixes coloring.
