### PR TITLE
Some CSS fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.project
 /.classpath
 /.settings
+.idea
+*.iml

--- a/src/main/resources/cucumber/formatter/formatter.js
+++ b/src/main/resources/cucumber/formatter/formatter.js
@@ -20,7 +20,7 @@ CucumberHTML.DOMFormatter = function(rootNode) {
   // Draw initial summary
   (function()
   {
-    $('.cucumber-report').append( '<div id="cucumber-header"><div id="label"><h1>Neo Cucumber Acceptance Testing</h1></div><div id="summary"><p id="totals"></p><p id="duration"></div>' );
+    $('.cucumber-report').append( '<div id="cucumber-header"><div id="label"><h1>Cucumber Features</h1></div><div id="summary"><p id="totals"></p><p id="duration"></div>' );
   })();
 
   function updateTotals() {
@@ -129,7 +129,11 @@ CucumberHTML.DOMFormatter = function(rootNode) {
 
       updateTotals();
 
-      currentElement.find('details').attr('open', 'open');
+      if (result.status != 'passed') {
+        currentElement.find('details').attr('open', 'open');
+      } else {
+        currentElement.find('details').removeAttr('open');
+      }
     }
   };
 

--- a/src/main/resources/cucumber/formatter/style.css
+++ b/src/main/resources/cucumber/formatter/style.css
@@ -1,7 +1,7 @@
 body {
-  font-size: 0px;
-  margin: 0px;
-  padding: 0px;
+  font-size: 0;
+  margin: 0;
+  padding: 0;
 }
 
 .cucumber-report {
@@ -33,13 +33,11 @@ body {
 
 .cucumber-report table {
   border-collapse: collapse;
-  border: 1px;
-  border-style: solid;
+  border: 1px solid;
 }
 
 .cucumber-report td, .cucumber-report th {
-  border: 1px;
-  border-style: solid;
+  border: 1px solid;
   padding-left: 4px;
   padding-right: 4px;
 }
@@ -82,6 +80,7 @@ body {
   font-size: 11px;
   background: #fffbd3;
   color: black;
+  overflow-x: auto;
 }
 
 #cucumber-templates {
@@ -127,8 +126,7 @@ body {
 
 .step {
   margin: 5px;
-  padding: 3px;
-  padding-left: 18px;
+  padding: 3px 3px 3px 18px;
   font-size: 11px;
 }
 
@@ -189,14 +187,14 @@ img {
 }
 
 h1 {
-  margin: 0px 10px;
+  margin: 0 10px;
   padding: 10px;
 }
 
 #summary {
   text-align: right;
   float: right;
-  padding: 0px 10px;
+  padding: 0 10px;
 }
 
 #cucumber-header {

--- a/src/main/resources/cucumber/formatter/style.css
+++ b/src/main/resources/cucumber/formatter/style.css
@@ -181,6 +181,7 @@ body {
 img {
   margin-top: 10px;
   display:block;
+  max-width: 100%;
 }
 
 #label {

--- a/src/main/resources/cucumber/formatter/style.css
+++ b/src/main/resources/cucumber/formatter/style.css
@@ -71,8 +71,8 @@ body {
 }
 
 .cucumber-report .comment {
-  margin 0;
-  padding 0;
+  margin: 0;
+  padding: 0;
 }
 
 .cucumber-report .error {


### PR DESCRIPTION
Some improvements on the report.

One of the things I encountered was, that when I was embedding screen shots, the images would be huge compared to the HTML report in the browser. So I added a max-width property in the CSS for the img tag. Images smaller than the width of the screen will not change size.

Furthermore I noticed there were two lines in the CSS that were missing come colons.

... and I ignored some files from my IDE in gitignore.
